### PR TITLE
feat: sample DQ rules and parsing

### DIFF
--- a/modules/deploy/dataplex.tf
+++ b/modules/deploy/dataplex.tf
@@ -37,6 +37,8 @@ resource "google_dataplex_datascan" "dq_scan" {
         column      = try(rules.value.column, null)
         ignore_null = try(rules.value.ignore_null, null)
         dimension   = rules.value.dimension
+        description = try(rules.value.description, null)
+        name        = try(rules.value.name, null)
         threshold   = try(rules.value.threshold, null)
 
         dynamic "non_null_expectation" {

--- a/modules/deploy/rules/orders.dev.yaml
+++ b/modules/deploy/rules/orders.dev.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 samplingPercent: 100
-rowFilter: 
+rowFilter:
 rules:
   - column: order_id
     dimension: COMPLETENESS
@@ -58,7 +58,7 @@ rules:
     threshold: 0.99
     range_expectation:
       max_value: '1'
-      # min_value: 
+      # min_value:
       strict_max_enabled: false
       strict_min_enabled: false
   - dimension: VALIDITY

--- a/modules/deploy/rules/orders.dev.yaml
+++ b/modules/deploy/rules/orders.dev.yaml
@@ -13,9 +13,56 @@
 # limitations under the License.
 
 samplingPercent: 100
+rowFilter: 
 rules:
+  - column: order_id
+    dimension: COMPLETENESS
+    name: non-null
+    description: Sample rule for non-null column
+    threshold: 1.0
+    non_null_expectation: {}
+  - column: user_id
+    dimension: COMPLETENESS
+    name: non-null
+    description: Sample rule for non-null column
+    threshold: 1.0
+    non_null_expectation: {}
+  - column: created_at
+    description: Sample rule for non-null column
+    dimension: COMPLETENESS
+    name: non-null
+    threshold: 1.0
+    non_null_expectation: {}
+  - column: order_id
+    dimension: UNIQUENESS
+    name: unique
+    description: Sample rule for unique column
+    uniqueness_expectation: {}
+  - column: status
+    dimension: VALIDITY
+    name: one-of-set
+    description: Sample rule for values in a set
+    ignore_null: false
+    set_expectation:
+      values:
+      - Shipped
+      - Complete
+      - Processing
+      - Cancelled
+      - Returned
+  - column: num_of_item
+    dimension: VALIDITY
+    name: range-values
+    description: Sample rule for values in a range
+    ignore_null: false
+    threshold: 0.99
+    range_expectation:
+      max_value: '1'
+      # min_value: 
+      strict_max_enabled: false
+      strict_min_enabled: false
   - dimension: VALIDITY
-    name: MY RULE
-    decription: SAMPLE RULE FOR VALIDITY
+    name: not-empty-table
+    description: Sample rule for a non-empty table
     tableConditionExpectation:
       sqlExpression: COUNT(*) > 0

--- a/modules/deploy/rules_file_parsing.tf
+++ b/modules/deploy/rules_file_parsing.tf
@@ -21,6 +21,8 @@ locals {
       column               = try(rule.column, null)
       ignore_null          = try(rule.ignoreNull, rule.ignore_null, null)
       dimension            = rule.dimension
+      description          = try(rule.description, null)
+      name                 = try(rule.name, null)
       threshold            = try(rule.threshold, null)
       non_null_expectation = try(rule.nonNullExpectation, rule.non_null_expectation, null)
       range_expectation = can(rule.rangeExpectation) || can(rule.range_expectation) ? {


### PR DESCRIPTION
- added list and template of sample Dataplex DQ rules
- added `name` and `description` fields to Dataplex DQ rules.
- updated rules_parsing to handle `name` and `description` fields