### PR TITLE
Set cloud logging only in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -92,3 +92,6 @@ steps:
         echo "*******************************************************************************"
       fi
 # [END tf-apply]
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
To fix the Cloud Build error:
`Your build failed to run: if 'build.service_account' is specified, the build must either (a) specify 'build.logs_bucket', (b) use the REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option, or (c) use either CLOUD_LOGGING_ONLY / NONE logging options: invalid argument`