### PR TITLE
feat: add sql_assertion dataplex rules handling in yaml parser

### DIFF
--- a/modules/deploy/rules_file_parsing.tf
+++ b/modules/deploy/rules_file_parsing.tf
@@ -51,6 +51,9 @@ locals {
       table_condition_expectation = can(rule.tableConditionExpectation) || can(rule.table_condition_expectation) ? {
         sql_expression = try(rule.tableConditionExpectation.sqlExpression, rule.table_condition_expectation.sql_expression, null)
       } : null
+      sql_assertion = can(rule.sqlAssertion) || can(rule.sql_assertion) ? {
+        sql_statement = try(rule.sqlAssertion.sqlStatement, rule.sql_assertion.sql_statement, null)
+      } : null
     }
   ]
 


### PR DESCRIPTION
When a SQL assertion is added to the YAML data_quality_spec file, the YAML parser does not handle it and the TF deployment fails. 

This change handles the SQL assertion rule type in the YAML.